### PR TITLE
feat: カレンダーから下からスライドインするツイート一覧UI (#22)

### DIFF
--- a/src/app/api/tweets/[year]/[month]/[day]/route.ts
+++ b/src/app/api/tweets/[year]/[month]/[day]/route.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { NextResponse } from 'next/server';
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ year: string; month: string; day: string }> }
+) {
+  const { year, month, day } = await context.params;
+
+  try {
+    const filePath = path.join(
+      process.cwd(),
+      'src',
+      'content',
+      'likes',
+      year,
+      month,
+      `${day}.json`,
+    );
+
+    const fileContent = await fs.readFile(filePath, 'utf-8');
+    const content = JSON.parse(fileContent);
+
+    return NextResponse.json(content);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/calendar-picker.tsx
+++ b/src/components/calendar-picker.tsx
@@ -4,7 +4,6 @@ import { Calendar } from '@/components/ui/calendar';
 import { useCalendarStore } from '@/store/calendar-store';
 import { DateInfo } from '@/types/like';
 import { toZonedTime } from 'date-fns-tz';
-import { useTransitionRouter } from 'next-view-transitions';
 import { useParams, usePathname } from 'next/navigation';
 import { useCallback, useEffect, useMemo } from 'react';
 
@@ -15,9 +14,8 @@ export function CalendarPicker({
   allDates: DateInfo[];
   isFooter?: boolean;
 }) {
-  const { selectedDate, setSelectedDate, displayMonth, setDisplayMonth } = useCalendarStore();
+  const { selectedDate, setSelectedDate, displayMonth, setDisplayMonth, setIsDrawerOpen } = useCalendarStore();
   const params = useParams();
-  const router = useTransitionRouter();
   const pathname = usePathname();
   const isRootPath = pathname === '/';
 
@@ -62,15 +60,13 @@ export function CalendarPicker({
     (date: Date | undefined) => {
       setSelectedDate(date);
       if (!date) {
-        router.push('/');
+        setIsDrawerOpen(false);
         return;
       }
-      const formattedDate = `/${date.getFullYear()}/${String(
-        date.getMonth() + 1,
-      ).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
-      router.push(formattedDate);
+      // ドロワーを開く
+      setIsDrawerOpen(true);
     },
-    [router, setSelectedDate],
+    [setSelectedDate, setIsDrawerOpen],
   );
 
   // 日付の無効化チェック
@@ -87,13 +83,13 @@ export function CalendarPicker({
   return (
     <div
       className={`flex items-center justify-center ${
-        isRootPath ? 'h-full' : ''
+        isRootPath ? 'h-[calc(100vh-12rem)]' : ''
       } ${isRootPath && isFooter ? 'hidden' : ''}`}
     >
       <Calendar
         mode="single"
-        className={`rounded-md border ${
-          isRootPath ? '' : 'max-w-[28rem] w-full'
+        className={`rounded-md border transition-transform duration-300 ${
+          isRootPath ? 'scale-110' : 'max-w-[28rem] w-full'
         }`}
         classNames={
           isRootPath

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -3,6 +3,8 @@
 import { ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import { CalendarPicker } from './calendar-picker';
+import { TweetDrawer } from './tweet-drawer';
+import { useCalendarStore } from '@/store/calendar-store';
 // import { SiteAnnounce } from './site-announce';
 import { DateInfo } from '@/types/like';
 
@@ -14,15 +16,28 @@ export function Main({
   allDates: DateInfo[];
 }) {
   const pathname = usePathname();
+  const { selectedDate, isDrawerOpen, setIsDrawerOpen } = useCalendarStore();
   
   // /tweet/[id] と /urls パスではカレンダーを表示しない
   const showCalendar = !pathname.startsWith('/tweet/') && !pathname.startsWith('/urls');
   
+  // ルートページの場合はchildrenを表示しない（カレンダーのみ表示）
+  const isRootPage = pathname === '/';
+  
   return (
-    <main className="container mx-auto px-4 py-4">
-      {/* <SiteAnnounce /> */}
-      {showCalendar && <CalendarPicker allDates={allDates} />}
-      {children}
-    </main>
+    <>
+      <main className={`container mx-auto px-4 py-4 transition-all duration-300 ${isDrawerOpen ? 'scale-95 opacity-40' : ''}`}>
+        {/* <SiteAnnounce /> */}
+        {showCalendar && <CalendarPicker allDates={allDates} />}
+        {!isRootPage && children}
+      </main>
+      
+      {/* Tweet Drawer */}
+      <TweetDrawer
+        isOpen={isDrawerOpen}
+        onClose={() => setIsDrawerOpen(false)}
+        date={selectedDate || null}
+      />
+    </>
   );
 }

--- a/src/components/tweet-drawer.tsx
+++ b/src/components/tweet-drawer.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import { CustomTweet } from '@/components/custom-tweet';
+import { DayJson } from '@/types/like';
+import { useCalendarStore } from '@/store/calendar-store';
+
+interface TweetDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  date: Date | null;
+}
+
+export function TweetDrawer({ isOpen, onClose, date }: TweetDrawerProps) {
+  const [content, setContent] = useState<DayJson | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!date || !isOpen) return;
+
+    const fetchContent = async () => {
+      setLoading(true);
+      try {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        
+        const response = await fetch(`/api/tweets/${year}/${month}/${day}`);
+        if (response.ok) {
+          const data = await response.json();
+          setContent(data);
+        } else {
+          setContent(null);
+        }
+      } catch (error) {
+        console.error('Failed to fetch tweets:', error);
+        setContent(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchContent();
+  }, [date, isOpen]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 bg-black/50 backdrop-blur-sm transition-all duration-300 z-40 ${
+          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={onClose}
+      />
+      
+      {/* Drawer */}
+      <div
+        className={`fixed inset-x-0 bottom-0 z-50 bg-gray-900 rounded-t-3xl shadow-2xl transition-all duration-300 ease-out transform ${
+          isOpen ? 'translate-y-0' : 'translate-y-full'
+        }`}
+        style={{ maxHeight: '90vh', touchAction: 'pan-y' }}
+      >
+        {/* Handle */}
+        <div className="flex justify-center pt-3">
+          <div className="w-12 h-1 bg-gray-600 rounded-full" />
+        </div>
+        
+        {/* Header */}
+        <div className="sticky top-0 bg-gray-900 px-4 py-4 border-b border-gray-800">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-100">
+                {date && (
+                  <>
+                    liked on: {date.getFullYear()}/
+                    {String(date.getMonth() + 1).padStart(2, '0')}/
+                    {String(date.getDate()).padStart(2, '0')}
+                  </>
+                )}
+              </h2>
+              <p className="text-sm text-gray-400">
+                {content?.body.length || 0} tweets
+              </p>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 rounded-full hover:bg-gray-800 transition-colors"
+            >
+              <X className="w-5 h-5 text-gray-400" />
+            </button>
+          </div>
+        </div>
+        
+        {/* Content */}
+        <div className="overflow-y-auto overscroll-contain" style={{ maxHeight: 'calc(90vh - 120px)' }}>
+          <div className="w-full max-w-md mx-auto space-y-4 p-4 pb-8">
+            {loading ? (
+              <div className="text-center py-8">
+                <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-300" />
+              </div>
+            ) : content === null ? (
+              <div className="text-center italic text-lg py-8">
+                Not Found : (ง ˙ω˙)ว
+              </div>
+            ) : (
+              content?.body.map(
+                (tweet) =>
+                  tweet.tweet_id && (
+                    <CustomTweet
+                      key={tweet.tweet_id}
+                      tweetData={tweet.react_tweet_data}
+                      tweetId={tweet.tweet_id}
+                      isPrivate={tweet.private}
+                      isNotFound={tweet.notfound}
+                    />
+                  ),
+              )
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/store/calendar-store.ts
+++ b/src/store/calendar-store.ts
@@ -6,6 +6,8 @@ type CalendarStore = {
   setSelectedDate: (date: Date | undefined) => void;
   displayMonth: Date | undefined;
   setDisplayMonth: (date: Date | undefined) => void;
+  isDrawerOpen: boolean;
+  setIsDrawerOpen: (isOpen: boolean) => void;
 };
 
 export const useCalendarStore = create<CalendarStore>((set) => ({
@@ -13,4 +15,6 @@ export const useCalendarStore = create<CalendarStore>((set) => ({
   setSelectedDate: (date) => set({ selectedDate: date }),
   displayMonth: undefined,
   setDisplayMonth: (date) => set({ displayMonth: date }),
+  isDrawerOpen: false,
+  setIsDrawerOpen: (isOpen) => set({ isDrawerOpen: isOpen }),
 }));


### PR DESCRIPTION
## 概要
カレンダークリック時の画面遷移を、下からスライドインするモダンなドロワーUIに変更しました。

## 変更内容
### 🎨 UI/UXの改善
- カレンダークリック時にページ遷移せず、ドロワーでツイート一覧を表示
- 下からスムーズにスライドインするアニメーション
- カレンダーは常に背景に表示され、ドロワー表示時はオーバーレイ効果

### 🛠️ 技術的な実装
- **TweetDrawer コンポーネント**: 下からスライドインするツイート一覧UI
- **APIルート追加**: `/api/tweets/[year]/[month]/[day]` でツイートデータを非同期取得
- **状態管理の拡張**: ZustandストアにisDrawerOpen状態を追加
- **モバイル対応**: タッチ操作に対応したスムーズなインタラクション

### 🎯 メリット
- より直感的でモダンなユーザー体験
- ページ遷移なしでスムーズな操作感
- カレンダーとツイート一覧の関係性が視覚的に分かりやすい
- 背景のカレンダーが常に見えるため、日付の切り替えが容易

## スクリーンショット
- カレンダークリック前：カレンダーが全画面表示
- ドロワー表示時：背景のカレンダーにオーバーレイ効果、下からツイート一覧がスライドイン

## 関連Issue
Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)