### PR TITLE
🐛 fix: react-tweetのentities欠落でビルドが失敗する問題を修正

### DIFF
--- a/src/components/custom-tweet.tsx
+++ b/src/components/custom-tweet.tsx
@@ -11,6 +11,32 @@ type TweetProps = {
   isNotFound: boolean;
 };
 
+// react-tweet の getEntities() は entities.hashtags / user_mentions / urls / symbols を
+// 無条件に for...of で走査するため、API レスポンスに該当キーが無いと
+// "TypeError: ... is not iterable" でビルド時のプリレンダリングが失敗する。
+// 入力を必ず配列に正規化してから渡す（quoted_tweet も同じ経路で処理されるので再帰）。
+type EntitiesShape = NonNullable<Tweet['entities']>;
+const normalizeEntities = (entities: Partial<EntitiesShape> | undefined): EntitiesShape => {
+  const e = entities ?? {};
+  return {
+    ...e,
+    hashtags: e.hashtags ?? [],
+    user_mentions: e.user_mentions ?? [],
+    urls: e.urls ?? [],
+    symbols: e.symbols ?? [],
+    media: e.media,
+  } as EntitiesShape;
+};
+const normalizeTweet = <T extends { entities?: Partial<EntitiesShape>; quoted_tweet?: unknown }>(
+  tweet: T,
+): T => ({
+  ...tweet,
+  entities: normalizeEntities(tweet.entities),
+  ...(tweet.quoted_tweet
+    ? { quoted_tweet: normalizeTweet(tweet.quoted_tweet as { entities?: Partial<EntitiesShape> }) }
+    : {}),
+});
+
 export const CustomTweet = ({
   tweetData,
   tweetId,
@@ -24,7 +50,7 @@ export const CustomTweet = ({
   return (
     <Suspense fallback={<TweetSkeleton />}>
       {tweetData ? (
-        <EmbeddedTweet tweet={tweetData} key={tweetId} />
+        <EmbeddedTweet tweet={normalizeTweet(tweetData)} key={tweetId} />
       ) : (
         <TweetNotFound />
       )}


### PR DESCRIPTION
## Summary
- デプロイ先で `pnpm build` が `TypeError: c is not iterable` で失敗していた問題を修正
- 原因は `react-tweet@3.2.2` の `getEntities()` が `entities.hashtags / user_mentions / urls / symbols` を無条件で `for...of` 走査するため、APIレスポンスでこれらが省略された tweet（保存済みデータで 4663 件中 52 件確認）で例外発生
- `CustomTweet` で `EmbeddedTweet` に渡す直前に欠落エンティティを `[]` に正規化（`quoted_tweet` も再帰）

## Test plan
- [x] `pnpm build` で 5672 件すべての静的ページ生成が成功することを確認
- [ ] デプロイ先（Vercel等）でのビルドが通ることを確認
- [ ] `/tweet/2057689279741198547` および `/likes/2026-05-22` がプレビューで正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)