### PR TITLE
🐛 fix: Main の未使用 allDates 引数で Vercel lint が失敗する問題

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,9 +5,6 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
 import { ViewTransitions } from 'next-view-transitions';
-import path from 'path';
-import { readdir } from 'fs/promises';
-import { cache } from 'react';
 import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
 import { GoogleAnalytics } from '@next/third-parties/google';
@@ -63,73 +60,11 @@ export const metadata: Metadata = {
   },
 };
 
-interface DateInfo {
-  year: string;
-  month: string;
-  day: string;
-}
-
-// getAllDatesをcacheで最適化
-const getAllDates = cache(async (): Promise<DateInfo[]> => {
-  const contentDir = path.join(process.cwd(), 'src/content/likes');
-
-  // 再帰的にJSONファイルを見つける関数
-  async function findJsonFiles(dir: string): Promise<string[]> {
-    const files = await readdir(dir, { withFileTypes: true });
-    const jsonFiles: string[] = [];
-
-    await Promise.all(
-      files.map(async (file) => {
-        const fullPath = path.join(dir, file.name);
-        if (file.isDirectory()) {
-          const nestedFiles = await findJsonFiles(fullPath);
-          jsonFiles.push(...nestedFiles);
-        } else if (file.name.endsWith('.json')) {
-          jsonFiles.push(fullPath);
-        }
-      }),
-    );
-
-    return jsonFiles;
-  }
-
-  try {
-    const jsonFiles = await findJsonFiles(contentDir);
-
-    const dates = jsonFiles
-      .map((filePath) => {
-        const relativePath = path.relative(contentDir, filePath);
-        const pathParts = relativePath.split(path.sep);
-
-        if (pathParts.length < 3) return null;
-
-        return {
-          year: pathParts[0],
-          month: pathParts[1],
-          day: pathParts[2].split('.')[0],
-        };
-      })
-      .filter((date): date is DateInfo => date !== null)
-      .sort((a, b) => {
-        const dateA = `${a.year}${a.month}${a.day}`;
-        const dateB = `${b.year}${b.month}${b.day}`;
-        return dateB.localeCompare(dateA);
-      });
-
-    return dates;
-  } catch (error) {
-    console.error('Error reading content directory:', error);
-    return [];
-  }
-});
-
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const allDates = await getAllDates();
-
   return (
     <ViewTransitions>
       <html lang="ja" className="dark">
@@ -139,9 +74,8 @@ export default async function RootLayout({
           <GoogleAnalytics gaId={process.env.GOOGLE_TAG_ID!} />
           <div className="grid grid-rows-[auto_1fr_auto] grid-cols-[100%] min-h-svh">
             <Header />
-            <Main allDates={allDates}>{children}</Main>
+            <Main>{children}</Main>
             <Footer>
-              {/* <CalendarPicker allDates={allDates} isFooter /> */}
               <ScrollTopButton />
             </Footer>
           </div>

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -2,15 +2,8 @@
 
 import { ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
-import { DateInfo } from '@/types/like';
 
-export function Main({
-  children,
-  allDates: _allDates,
-}: {
-  children: ReactNode;
-  allDates: DateInfo[];
-}) {
+export function Main({ children }: { children: ReactNode }) {
   // 各ルートが独自レイアウトを持つようになったので、Main は単純な main 要素に。
   // /tweet/[id] と /likes/[date] は削除済み (検索/カテゴリに統合)。
   const pathname = usePathname();


### PR DESCRIPTION
@typescript-eslint/no-unused-vars が `_` プレフィックスを許容しない 設定だったため、Vercel の build で

  './src/components/main.tsx:9:13  Error: '_allDates' is defined but
  never used'

として fail していた。Phase E で /tweet/[id] と /likes/[date] を 削除した段階で Main は allDates を実際に使わなくなっていたので、
prop ごと削除して根本解消する。

ついでに layout.tsx の `getAllDates` / `cache` / `path` / `readdir` の import と計算ロジックも、Main に渡す目的だけのデッドコードだった
ので除去 (build trace から fs scan を 1 つ削減)。