### PR TITLE
🐛 fix: search-cli の let → const (Vercel prefer-const lint)

### DIFF
--- a/src/scripts/search-cli.ts
+++ b/src/scripts/search-cli.ts
@@ -149,8 +149,8 @@ async function main() {
   const docs = await loadDocs();
   process.stderr.write(`[load] ${docs.length} docs, ${docs.filter((d) => d.embedding).length} with embedding\n`);
 
-  let ftsScores = new Map<string, number>();
-  let semScores = new Map<string, number>();
+  const ftsScores = new Map<string, number>();
+  const semScores = new Map<string, number>();
 
   if (args.mode === 'fts' || args.mode === 'hybrid') {
     const ms = new MiniSearch({


### PR DESCRIPTION
src/scripts/search-cli.ts L152-153 の `let ftsScores` / `let semScores` が再代入されていないため Vercel build で

  152:7  Error: 'ftsScores' is never reassigned. Use 'const' instead.
  153:7  Error: 'semScores' is never reassigned. Use 'const' instead.

として fail していた。const に変更。

ローカルでも親 .eslintrc.json を一時退避して Vercel と同条件の
`pnpm build` (next lint 含む) を流して clean なことを確認済み。