### PR TITLE
⚡️ perf: Function bundle 250 MB 超過を解消 (outputFileTracingExcludes)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,27 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  // data/likes.db を Vercel の Function bundle に含める
-  // (server component から better-sqlite3 / libsql で読むため)
-  outputFileTracingIncludes: {
-    '/**/*': ['./data/likes.db'],
+  // Phase E 以降は全ページ force-static。Server Component の SQLite アクセスは
+  // BUILD 時のみで、runtime の Lambda Function には DB / 元 JSON / 重い script
+  // 系依存を一切含めない。
+  // outputFileTracingExcludes のキーは "*" (全ページ) を指定。
+  outputFileTracingExcludes: {
+    '*': [
+      // build 時にしか使わないデータと scripts
+      './data/**/*',
+      './src/content/**/*',
+      './src/scripts/**/*',
+      './src/assets/**/*',
+      './public/data/**/*',
+      // runtime では使わない依存 (script ベース or client dynamic import)
+      './node_modules/@huggingface/**/*',
+      './node_modules/@libsql/**/*',
+      './node_modules/algoliasearch/**/*',
+      './node_modules/react-tweet/**/*',
+      './node_modules/@aws-sdk/**/*',
+      './node_modules/onnxruntime-**/**/*',
+      './node_modules/minisearch/**/*',
+    ],
   },
 };
 


### PR DESCRIPTION
Vercel から

  A Serverless Function has exceeded the unzipped maximum size of 250 MB

と通知された。原因は Phase 1 で入れた

  outputFileTracingIncludes: { '/**/*': ['./data/likes.db'] }

が、Phase E 以降は不要 (全ルート force-static で runtime DB アクセスなし) であるにも関わらず 59 MB の SQLite を全 Function bundle に同梱していたため。 さらに src/content/likes/**/*.json (69 MB) と @libsql / @huggingface / minisearch / onnxruntime / @aws-sdk といった重い node_modules も自動 trace されていた。

対応:
- include を全削除し、代わりに outputFileTracingExcludes で:
  - data/, src/content/, src/scripts/, src/assets/, public/data/
  - @huggingface, @libsql, algoliasearch, react-tweet, @aws-sdk, onnxruntime-*, minisearch を Function bundle から除外。
- これらは BUILD 時 (prebuild の build-search-assets / page.tsx の getDb() 呼び出し / ai:embed 等) でしか使わない、または client-side の 動的 import 経由でしか使われない。

実測 (以前 / 以降):
- / page.js.nft.json     : 730 files → 53 files (1.3 MB)
- /search                : 同上 (1.3 MB)
- /categories/[slug]     : 52 files (1.3 MB)
- /archive/[page]        : 53 files (1.3 MB)
- /urls/[page]           : 53 files (1.3 MB)

likes.db / src/content / @libsql / minisearch / @huggingface / onnxruntime の trace 数を 0 確認済み。