### PR TITLE
🔧 chore: onnxruntime-node の postinstall を Vercel でスキップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,10 @@
     "cz-customizable": {
       "config": ".cz-config.cts"
     }
+  },
+  "pnpm": {
+    "neverBuiltDependencies": [
+      "onnxruntime-node"
+    ]
   }
 }


### PR DESCRIPTION
Vercel build で

  .../node_modules/onnxruntime-node postinstall: Error: connect ENETUNREACH
  Command "pnpm install" exited with 1

として fail していた。onnxruntime-node は @huggingface/transformers の Node.js 推論 backend (CUDA バイナリ DL を伴う postinstall) だが、本 プロジェクトでは transformers は

  - クライアント (WASM backend) で dynamic import するのみ
  - サーバ runtime からは一切呼ばない (next.config.ts でも除外済み)
  - 開発用スクリプト (embed-likes / search-cli) のみ Node 側で利用

なので runtime には不要。pnpm.neverBuiltDependencies に
onnxruntime-node を追加し、Vercel のクリーンインストール時に
postinstall を実行しないようにする。

ローカル script は事前 DL 済みの binary が node_modules にあれば
動くため、開発側の影響なし (もし新規環境でローカル ai:embed を
走らせる必要があれば手動で再インストールするか、neverBuilt の
リストから一時的に外す)。