### PR TITLE
🐛 fix: podcast ビルドの lint エラーを修正 (prefer-const + slider aria)

### DIFF
--- a/src/components/podcast-player.tsx
+++ b/src/components/podcast-player.tsx
@@ -117,7 +117,16 @@ export function PodcastPlayer() {
 
       <div className={`zk-player ${expanded ? 'zk-player-expanded' : ''}`} role="region" aria-label="ポッドキャストプレイヤー">
         {/* 進捗バー (mini/expanded 共通、上辺) */}
-        <div className="zk-player-progress" onClick={onSeekBar} role="slider" aria-label="再生位置" tabIndex={0}>
+        <div
+          className="zk-player-progress"
+          onClick={onSeekBar}
+          role="slider"
+          aria-label="再生位置"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(pct)}
+          tabIndex={0}
+        >
           <div className="zk-player-progress-fill" style={{ width: `${pct}%` }} />
         </div>
 

--- a/src/scripts/podcast/fetch-period.ts
+++ b/src/scripts/podcast/fetch-period.ts
@@ -43,7 +43,7 @@ function daysAgo(baseYmd: string, n: number): string {
 }
 
 function resolvePeriod(args: Args): PeriodSpec {
-  let to = args.to ?? todayJST();
+  const to = args.to ?? todayJST();
   let from = args.from;
   if (!from) {
     const days = args.days && Number.isFinite(args.days) && args.days > 0 ? args.days : 7;


### PR DESCRIPTION
## 背景

PR #52 マージ後の `main` 本番 Vercel ビルドが lint で失敗していた。

```
./src/scripts/podcast/fetch-period.ts
46:7  Error: 'to' is never reassigned. Use 'const' instead.  prefer-const
./src/components/podcast-player.tsx
120:65  Warning: slider must have aria-valuenow  jsx-a11y/role-has-required-aria-props
```

## 修正

- `fetch-period.ts`: 再代入しない `to` を `const` に (prefer-const, **build を落としていた Error**)
- `podcast-player.tsx`: progress slider に `aria-valuemin/max/now` を付与 (Warning)

## 検証

親階層 `.eslintrc.json` を一時退避し Vercel と同条件で該当2ファイルを lint → `✔ No ESLint warnings or errors`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)