### PR TITLE
✨ feat: ツイート埋め込みの固まり解消 + matrix ローダー + 日付ビュー浮遊カレンダー

### DIFF
--- a/public/matrix-loader.svg
+++ b/public/matrix-loader.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="92" height="92" viewBox="0 0 92 92">
+  <defs>
+    <filter id="hdr-glow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="2.1" result="blur1"/>
+      <feGaussianBlur in="SourceGraphic" stdDeviation="5.6" result="blur2"/>
+      <feGaussianBlur in="SourceGraphic" stdDeviation="10.5" result="blur3"/>
+      <feColorMatrix in="blur1" type="matrix" result="glow1"
+        values="0 0 0 0 0.424 0 0 0 0 0.706 0 0 0 0 1.000 0 0 0 0.560 0"/>
+      <feColorMatrix in="blur2" type="matrix" result="glow2"
+        values="0 0 0 0 0.424 0 0 0 0 0.706 0 0 0 0 1.000 0 0 0 0.350 0"/>
+      <feColorMatrix in="blur3" type="matrix" result="glow3"
+        values="0 0 0 0 0.424 0 0 0 0 0.706 0 0 0 0 1.000 0 0 0 0.210 0"/>
+      <feMerge>
+        <feMergeNode in="glow3"/>
+        <feMergeNode in="glow2"/>
+        <feMergeNode in="glow1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <!-- Off cells -->
+  <g>
+  <rect x="0" y="0" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="19" y="0" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="38" y="0" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="57" y="0" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="76" y="0" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="0" y="19" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="19" y="19" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="38" y="19" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="57" y="19" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="76" y="19" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="0" y="38" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="19" y="38" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="38" y="38" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="57" y="38" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="76" y="38" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="0" y="57" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="19" y="57" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="38" y="57" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="57" y="57" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="76" y="57" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="0" y="76" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="19" y="76" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="38" y="76" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="57" y="76" width="16" height="16" rx="2" fill="#101B26"/>
+  <rect x="76" y="76" width="16" height="16" rx="2" fill="#101B26"/>
+  </g>
+  <!-- On cells with animation -->
+  <g filter="url(#hdr-glow)">
+  <rect x="0" y="0" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.500;0.371;0.250;0.146;0.067;0.017;0.000;0.017;0.067;0.146;0.250;0.371;0.500;0.629;0.750;0.854;0.933;0.983;1.000;0.983;0.933;0.854;0.750;0.629" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="19" y="0" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.859;0.756;0.636;0.507;0.378;0.256;0.152;0.071;0.019;0.000;0.015;0.063;0.141;0.244;0.364;0.493;0.622;0.744;0.848;0.929;0.981;1.000;0.985;0.937" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="38" y="0" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="1.000;0.987;0.940;0.864;0.763;0.643;0.515;0.385;0.263;0.157;0.074;0.021;0.000;0.013;0.060;0.136;0.237;0.357;0.485;0.615;0.737;0.843;0.926;0.979" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="57" y="0" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.838;0.922;0.977;1.000;0.988;0.944;0.869;0.769;0.650;0.522;0.392;0.269;0.162;0.078;0.023;0.000;0.012;0.056;0.131;0.231;0.350;0.478;0.608;0.731" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="76" y="0" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.471;0.601;0.724;0.832;0.918;0.975;0.999;0.990;0.947;0.874;0.775;0.657;0.529;0.399;0.276;0.168;0.082;0.025;0.001;0.010;0.053;0.126;0.225;0.343" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="0" y="19" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.859;0.756;0.636;0.507;0.378;0.256;0.152;0.071;0.019;0.000;0.015;0.063;0.141;0.244;0.364;0.493;0.622;0.744;0.848;0.929;0.981;1.000;0.985;0.937" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="19" y="19" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="1.000;0.987;0.940;0.864;0.763;0.643;0.515;0.385;0.263;0.157;0.074;0.021;0.000;0.013;0.060;0.136;0.237;0.357;0.485;0.615;0.737;0.843;0.926;0.979" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="38" y="19" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.838;0.922;0.977;1.000;0.988;0.944;0.869;0.769;0.650;0.522;0.392;0.269;0.162;0.078;0.023;0.000;0.012;0.056;0.131;0.231;0.350;0.478;0.608;0.731" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="57" y="19" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.471;0.601;0.724;0.832;0.918;0.975;0.999;0.990;0.947;0.874;0.775;0.657;0.529;0.399;0.276;0.168;0.082;0.025;0.001;0.010;0.053;0.126;0.225;0.343" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="76" y="19" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.122;0.219;0.336;0.464;0.594;0.718;0.827;0.914;0.972;0.999;0.991;0.950;0.878;0.781;0.664;0.536;0.406;0.282;0.173;0.086;0.028;0.001;0.009;0.050" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="0" y="38" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="1.000;0.987;0.940;0.864;0.763;0.643;0.515;0.385;0.263;0.157;0.074;0.021;0.000;0.013;0.060;0.136;0.237;0.357;0.485;0.615;0.737;0.843;0.926;0.979" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="19" y="38" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.838;0.922;0.977;1.000;0.988;0.944;0.869;0.769;0.650;0.522;0.392;0.269;0.162;0.078;0.023;0.000;0.012;0.056;0.131;0.231;0.350;0.478;0.608;0.731" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="38" y="38" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.471;0.601;0.724;0.832;0.918;0.975;0.999;0.990;0.947;0.874;0.775;0.657;0.529;0.399;0.276;0.168;0.082;0.025;0.001;0.010;0.053;0.126;0.225;0.343" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="57" y="38" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.122;0.219;0.336;0.464;0.594;0.718;0.827;0.914;0.972;0.999;0.991;0.950;0.878;0.781;0.664;0.536;0.406;0.282;0.173;0.086;0.028;0.001;0.009;0.050" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="76" y="38" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.002;0.008;0.047;0.117;0.213;0.329;0.456;0.587;0.711;0.821;0.909;0.970;0.998;0.992;0.953;0.883;0.787;0.671;0.544;0.413;0.289;0.179;0.091;0.030" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="0" y="57" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.838;0.922;0.977;1.000;0.988;0.944;0.869;0.769;0.650;0.522;0.392;0.269;0.162;0.078;0.023;0.000;0.012;0.056;0.131;0.231;0.350;0.478;0.608;0.731" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="19" y="57" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.471;0.601;0.724;0.832;0.918;0.975;0.999;0.990;0.947;0.874;0.775;0.657;0.529;0.399;0.276;0.168;0.082;0.025;0.001;0.010;0.053;0.126;0.225;0.343" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="38" y="57" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.122;0.219;0.336;0.464;0.594;0.718;0.827;0.914;0.972;0.999;0.991;0.950;0.878;0.781;0.664;0.536;0.406;0.282;0.173;0.086;0.028;0.001;0.009;0.050" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="57" y="57" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.002;0.008;0.047;0.117;0.213;0.329;0.456;0.587;0.711;0.821;0.909;0.970;0.998;0.992;0.953;0.883;0.787;0.671;0.544;0.413;0.289;0.179;0.091;0.030" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="76" y="57" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.184;0.095;0.033;0.003;0.006;0.044;0.112;0.207;0.322;0.449;0.579;0.705;0.816;0.905;0.967;0.997;0.994;0.956;0.888;0.793;0.678;0.551;0.421;0.295" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="0" y="76" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.471;0.601;0.724;0.832;0.918;0.975;0.999;0.990;0.947;0.874;0.775;0.657;0.529;0.399;0.276;0.168;0.082;0.025;0.001;0.010;0.053;0.126;0.225;0.343" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="19" y="76" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.122;0.219;0.336;0.464;0.594;0.718;0.827;0.914;0.972;0.999;0.991;0.950;0.878;0.781;0.664;0.536;0.406;0.282;0.173;0.086;0.028;0.001;0.009;0.050" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="38" y="76" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.002;0.008;0.047;0.117;0.213;0.329;0.456;0.587;0.711;0.821;0.909;0.970;0.998;0.992;0.953;0.883;0.787;0.671;0.544;0.413;0.289;0.179;0.091;0.030" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="57" y="76" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.184;0.095;0.033;0.003;0.006;0.044;0.112;0.207;0.322;0.449;0.579;0.705;0.816;0.905;0.967;0.997;0.994;0.956;0.888;0.793;0.678;0.551;0.421;0.295" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="76" y="76" width="16" height="16" rx="2" fill="#6cb4ff">
+    <animate attributeName="opacity" values="0.558;0.428;0.302;0.190;0.099;0.035;0.003;0.005;0.041;0.108;0.201;0.315;0.442;0.572;0.698;0.810;0.901;0.965;0.997;0.995;0.959;0.892;0.799;0.685" dur="1.000s" repeatCount="indefinite"/>
+  </rect>
+  </g>
+</svg>

--- a/src/components/search-page-client.tsx
+++ b/src/components/search-page-client.tsx
@@ -201,6 +201,9 @@ export function SearchPageClient() {
   // 日付チップから別の日付に切り替えるとき用。assets が読まれた後は
   // 利用可能な日付のみ enable する Calendar を popover に出す。
   const [datePickerOpen, setDatePickerOpen] = useState(false);
+  // 日付ビューで下までスクロールしたときに出す浮遊カレンダー (別日付ジャンプ用)
+  const [floatingPickerOpen, setFloatingPickerOpen] = useState(false);
+  const [showDateFab, setShowDateFab] = useState(false);
   // podcast がある週の日付を ● マーク
   const podcastDateSet = useMemo(() => buildPodcastDateSet(), []);
   const changeDate = useCallback(
@@ -216,9 +219,26 @@ export function SearchPageClient() {
       sp.set('date', ymd);
       router.replace(`${pathname}?${sp.toString()}`);
       setDatePickerOpen(false);
+      setFloatingPickerOpen(false);
+      // 別の日付に切り替えたら、新しい日の先頭から見られるようトップへ戻す
+      if (typeof window !== 'undefined') {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
     },
     [router, pathname, searchParams],
   );
+
+  // 日付ビューで一定以上スクロールしたら、別日付ジャンプ用 FAB を出す
+  useEffect(() => {
+    if (!dateFilter) {
+      setShowDateFab(false);
+      return;
+    }
+    const onScroll = () => setShowDateFab(window.scrollY > 500);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [dateFilter]);
 
   // ---- iOS / iOS PWA 判定 (一度だけ) ----
   // iOS Safari / PWA は transformers.js (WASM + IndexedDB) が不安定で、
@@ -963,6 +983,56 @@ export function SearchPageClient() {
             </button>
           )}
         </>
+      )}
+
+      {/* 日付ビューで下までスクロールしたとき、トップに戻らず別日付へ飛べる FAB */}
+      {dateFilter && showDateFab && (
+        <Popover open={floatingPickerOpen} onOpenChange={setFloatingPickerOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="別の日付へ移動"
+              style={{
+                position: 'fixed',
+                right: 'max(16px, env(safe-area-inset-right))',
+                bottom: 'max(20px, env(safe-area-inset-bottom))',
+                zIndex: 50,
+                width: 52,
+                height: 52,
+                borderRadius: 999,
+                border: 0,
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: 'var(--bg-2)',
+                color: 'var(--zk-accent)',
+                boxShadow: '0 6px 22px rgba(0,0,0,0.5), inset 0 0 0 1px var(--zk-accent-line)',
+              }}
+            >
+              <CalendarDays size={20} strokeWidth={1.9} />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="end" side="top" className="w-auto p-2">
+            <Calendar
+              mode="single"
+              selected={dateFilterAsDate}
+              onSelect={changeDate}
+              modifiers={{ podcast: (date) => podcastDateSet.has(toYmd(date)) }}
+              modifiersClassNames={{ podcast: 'zk-day-podcast' }}
+              disabled={(date) => {
+                if (availableDateSet.size === 0) return false;
+                const ymd = `${date.getFullYear()}-${String(
+                  date.getMonth() + 1,
+                ).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+                return !availableDateSet.has(ymd);
+              }}
+              fromDate={fromDate}
+              toDate={toDate}
+              defaultMonth={dateFilterAsDate}
+            />
+          </PopoverContent>
+        </Popover>
       )}
     </div>
   );

--- a/src/components/tweet-embed-card.tsx
+++ b/src/components/tweet-embed-card.tsx
@@ -203,12 +203,8 @@ function LazyTweetEmbed({
   return (
     <div ref={containerRef} style={{ minHeight: state === 'idle' || state === 'loading' ? 120 : 0 }}>
       {/* widgets.js が iframe を埋める対象。最終的にこのノードの中に
-          iframe が挿入される (widgets.js が我々の placeholder を replace する仕様)。
-          missing / error 時は (timeout 後に遅れて iframe が来ても) 見せないよう隠す。 */}
-      <div
-        ref={placeholderRef}
-        style={{ display: state === 'missing' || state === 'error' ? 'none' : undefined }}
-      />
+          iframe が挿入される (widgets.js が我々の placeholder を replace する仕様)。 */}
+      <div ref={placeholderRef} />
       {state === 'loading' && (
         <div
           style={{

--- a/src/components/tweet-embed-card.tsx
+++ b/src/components/tweet-embed-card.tsx
@@ -203,21 +203,36 @@ function LazyTweetEmbed({
   return (
     <div ref={containerRef} style={{ minHeight: state === 'idle' || state === 'loading' ? 120 : 0 }}>
       {/* widgets.js が iframe を埋める対象。最終的にこのノードの中に
-          iframe が挿入される (widgets.js が我々の placeholder を replace する仕様)。 */}
-      <div ref={placeholderRef} />
+          iframe が挿入される (widgets.js が我々の placeholder を replace する仕様)。
+          missing / error 時は (timeout 後に遅れて iframe が来ても) 見せないよう隠す。 */}
+      <div
+        ref={placeholderRef}
+        style={{ display: state === 'missing' || state === 'error' ? 'none' : undefined }}
+      />
       {state === 'loading' && (
         <div
           style={{
             display: 'flex',
+            flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
+            gap: 8,
             height: 120,
-            color: 'var(--text-3)',
-            fontSize: 11.5,
           }}
-          className="font-mono"
+          aria-live="polite"
         >
-          loading post…
+          {/* matrix-loader: SMIL アニメーション SVG。img なら確実にアニメする */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/matrix-loader.svg"
+            alt=""
+            width={52}
+            height={52}
+            style={{ display: 'block' }}
+          />
+          <span className="font-mono" style={{ color: 'var(--text-3)', fontSize: 11.5 }}>
+            loading post…
+          </span>
         </div>
       )}
       {state === 'missing' && (

--- a/src/lib/twitter-widgets.ts
+++ b/src/lib/twitter-widgets.ts
@@ -111,36 +111,13 @@ export function loadWidgets(): Promise<Twttr> {
 export async function createTweetEmbed(
   tweetId: string,
   container: HTMLElement,
-  options: {
-    theme?: 'dark' | 'light';
-    dnt?: boolean;
-    conversation?: 'none' | 'all';
-    /** これを過ぎても createTweet が解決しなければ null 扱い (notfound 表示へ)。0 で無効。 */
-    timeoutMs?: number;
-  } = {},
+  options: { theme?: 'dark' | 'light'; dnt?: boolean; conversation?: 'none' | 'all' } = {},
 ): Promise<HTMLElement | null> {
-  const { timeoutMs = 9000, ...rest } = options;
-
-  // widgets.js のロード〜createTweet までを 1 つの work にまとめる。
-  // 削除済み / 取得不能ツイートは createTweet が解決しないまま固まることがあり
-  // (= 永遠に "loading post…")、ロード失敗もありうるので timeout と race して
-  // null に倒し、呼び出し側で notfound 表示に分岐できるようにする。
-  const work = (async () => {
-    const twttr = await loadWidgets();
-    return twttr.widgets.createTweet(tweetId, container, {
-      theme: 'dark',
-      dnt: true,
-      conversation: 'all',
-      ...rest,
-    });
-  })().catch(() => null);
-
-  if (timeoutMs <= 0) return work;
-
-  return Promise.race([
-    work,
-    new Promise<HTMLElement | null>((resolve) => {
-      setTimeout(() => resolve(null), timeoutMs);
-    }),
-  ]);
+  const twttr = await loadWidgets();
+  return twttr.widgets.createTweet(tweetId, container, {
+    theme: 'dark',
+    dnt: true,
+    conversation: 'all',
+    ...options,
+  });
 }

--- a/src/lib/twitter-widgets.ts
+++ b/src/lib/twitter-widgets.ts
@@ -111,13 +111,36 @@ export function loadWidgets(): Promise<Twttr> {
 export async function createTweetEmbed(
   tweetId: string,
   container: HTMLElement,
-  options: { theme?: 'dark' | 'light'; dnt?: boolean; conversation?: 'none' | 'all' } = {},
+  options: {
+    theme?: 'dark' | 'light';
+    dnt?: boolean;
+    conversation?: 'none' | 'all';
+    /** これを過ぎても createTweet が解決しなければ null 扱い (notfound 表示へ)。0 で無効。 */
+    timeoutMs?: number;
+  } = {},
 ): Promise<HTMLElement | null> {
-  const twttr = await loadWidgets();
-  return twttr.widgets.createTweet(tweetId, container, {
-    theme: 'dark',
-    dnt: true,
-    conversation: 'all',
-    ...options,
-  });
+  const { timeoutMs = 9000, ...rest } = options;
+
+  // widgets.js のロード〜createTweet までを 1 つの work にまとめる。
+  // 削除済み / 取得不能ツイートは createTweet が解決しないまま固まることがあり
+  // (= 永遠に "loading post…")、ロード失敗もありうるので timeout と race して
+  // null に倒し、呼び出し側で notfound 表示に分岐できるようにする。
+  const work = (async () => {
+    const twttr = await loadWidgets();
+    return twttr.widgets.createTweet(tweetId, container, {
+      theme: 'dark',
+      dnt: true,
+      conversation: 'all',
+      ...rest,
+    });
+  })().catch(() => null);
+
+  if (timeoutMs <= 0) return work;
+
+  return Promise.race([
+    work,
+    new Promise<HTMLElement | null>((resolve) => {
+      setTimeout(() => resolve(null), timeoutMs);
+    }),
+  ]);
 }


### PR DESCRIPTION
## 概要
本体サイトの3点を改善。

### ① not found ツイートが「loading post…」のまま固まる問題を解消
- 削除済み等で `widgets.js` の `createTweet` が解決しないまま固まり、永遠に「loading post…」になっていた。
- `createTweetEmbed` に **9s timeout** を追加し、解決しない/ロード失敗を `null` に倒して既存の「このポストは表示できません」表示へ分岐。
- timeout 後に遅れて iframe が来ても見せないよう、`missing`/`error` 時は placeholder を非表示に。

### ② loading に視覚的アニメーション
- `matrix-loader.svg`（SMIL アニメ）を `public/` に配置し、loading 表示を SVG ローダー + 「loading post…」テキストに差し替え。
- 位相違いの重複 SVG (`matrix-loader (1).svg`) は不要なので削除。

### ③ 日付ビューで下スクロールから別日付へジャンプ
- カレンダーから特定日のいいねを見ている際、下までスクロールするとトップの日付チップ（カレンダー）に戻れず不便だった。
- 一定以上スクロールすると **浮遊 FAB**（右下）を表示。タップで同じカレンダー Popover を開き、別日付へ直接ジャンプ。
- 日付切替後は新しい日の先頭から見られるようトップへスクロール。

## 確認
- `pnpm build` 通過（lint・型チェック・静的生成 OK）
- Vercel プレビューでローダーのアニメーションと FAB の動作を目視確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)