### PR TITLE
🐛 json:conv が削除済み重複を毎回再生成する問題を修正 (#42)

### DIFF
--- a/src/scripts/likes-processor.ts
+++ b/src/scripts/likes-processor.ts
@@ -1,10 +1,56 @@
 import { join } from 'path';
-import { readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  mkdirSync,
+  statSync,
+} from 'fs';
 import type { DayJson, Like } from '../types/like';
 import { getTweetIdFromUrl } from '../lib/tweet-helper';
 import { promises as fs } from 'fs';
 import { parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
+
+/**
+ * 既存の日別 JSON を全走査して、登録済み tweet_id の集合を作る。
+ *
+ * json:conv の重複チェックは元々「同じ日付ファイル内」しか見ておらず、
+ * remove-duplicate-tweets.ts は「全日付ファイル横断」で重複を 1 件に集約する。
+ * この非対称性のため、同一 tweet_id が複数の生データから別々の日付に振り分け
+ * られると、削除 → 次の conv で再生成、を毎回繰り返していた (issue #42)。
+ *
+ * conv 側でもグローバルに既存 tweet_id を把握し、どこかに存在する ID は二度と
+ * 追加しないことで、remove-duplicates と同じ「全体で 1 件」のポリシーに揃える。
+ */
+function collectExistingTweetIds(contentDir: string): Set<string> {
+  const ids = new Set<string>();
+  const walk = (dir: string) => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return; // ディレクトリが無い (初回) 場合は空集合
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+      } else if (entry.endsWith('.json')) {
+        try {
+          const dayJson: DayJson = JSON.parse(readFileSync(full, 'utf-8'));
+          for (const tweet of dayJson.body ?? []) {
+            if (tweet.tweet_id) ids.add(tweet.tweet_id);
+          }
+        } catch {
+          // 壊れた JSON はスキップ
+        }
+      }
+    }
+  };
+  walk(contentDir);
+  return ids;
+}
 
 export async function processAndGenerateContent() {
   try {
@@ -15,6 +61,10 @@ export async function processAndGenerateContent() {
 
     // コンテンツディレクトリがない場合は作成
     mkdirSync(contentDir, { recursive: true });
+
+    // 全日付ファイル横断で既存 tweet_id を把握 (issue #42 の重複再生成対策)。
+    // 以降、いずれかの日付ファイルに既出の ID は追加しない。
+    const knownTweetIds = collectExistingTweetIds(contentDir);
 
     // tweets_v2ディレクトリがあるかチェック
     const tweetsV2Dir = join(dataDir, 'tweets_v2');
@@ -47,6 +97,13 @@ export async function processAndGenerateContent() {
         data.tweet_id = tweetId;
         data.private = data.private ?? false;
         data.notfound = data.notfound ?? false;
+
+        // 既にいずれかの日付ファイルに存在する tweet_id は追加しない
+        // (issue #42: 削除済み重複の再生成を防ぐ)
+        if (knownTweetIds.has(tweetId)) {
+          continue;
+        }
+        knownTweetIds.add(tweetId);
 
         // 不要な情報の削除
         if (data.embed_code) {
@@ -127,6 +184,13 @@ export async function processAndGenerateContent() {
         data.tweet_id = tweetId;
         data.private = false;
         data.notfound = false;
+
+        // 既にいずれかの日付ファイルに存在する tweet_id は追加しない
+        // (issue #42: 削除済み重複の再生成を防ぐ)
+        if (knownTweetIds.has(tweetId)) {
+          continue;
+        }
+        knownTweetIds.add(tweetId);
 
         // 不要な情報の削除
         if (data.embed_code) {


### PR DESCRIPTION
Fixes #42

## 原因

データパイプラインの重複処理に非対称性があった:

- **`likes-processor.ts`(`json:conv`)**: 重複チェックが **同じ日付ファイル内** だけ(`dayJson.body.some(...)`)。他の日付ファイルに同一 `tweet_id` が存在するかは見ていない。
- **`remove-duplicate-tweets.ts`(`json:remove-duplicates`)**: **全日付ファイルを横断** して `tweet_id` で重複を検出し、最古の `liked_at` 1件だけ残して他を削除。

このため、同一 `tweet_id` が複数の生データ(`tweets_v2` / 旧構造、`liked_at` が別日にまたがる等)から別々の日付ファイルへ振り分けられると:

`json:conv`（重複生成）→ `remove-duplicates`（削除）→ 生データは残るので次の `json:conv` が **また同じ重複を生成** … という無駄なループを毎回繰り返していた。

## 修正

`json:conv` の開始時に既存の全日付ファイルを走査して **グローバルな `tweet_id` 集合**を構築し、いずれかの日付ファイルに既出の ID は追加しないようにした。これで `remove-duplicates` と同じ「全体で1件」ポリシーに揃う。既存ファイルには最古 occurrence が残っているため oldest-wins も維持される。

新旧両方の処理ループ(`tweets_v2` / 旧年月ディレクトリ)に適用。

## 検証

ローカルの生データ(`tweets_v2` 2,470件)+ 現行 content(クロスファイル重複 0 件)で確認:

| | クロスファイル重複 | content の差分 |
|---|---|---|
| 修正前の `json:conv` 1回 | **146 件再生成**（issue のサマリと一致） | あり |
| 修正後の `json:conv` 1回 | **0 件** | **なし（冪等）** |

- `eslint` パス
- 既存ツイートの保持・新規ツイートの追加経路は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)