### PR TITLE
✨ feat: トップに「讚の庭」桜バナーを追加

### DIFF
--- a/.github/workflows/process-json.yml
+++ b/.github/workflows/process-json.yml
@@ -65,6 +65,12 @@ jobs:
       - name: '📊 Build activity data'
         run: pnpm json:build-activity
 
+      - name: '🌳 Build garden stats'
+        # トップの「讚の庭」桜バナー用 (public/garden-stats.json)。
+        # totalLikes/elapsedDays は今 enrich した JSON から、カテゴリ別の花色比率は
+        # コミット済み data/likes.db から集計する。
+        run: pnpm json:build-garden
+
       # SQLite (data/likes.db) への取り込み・embedding 生成・サイトビルドは
       # ここでは行わない。ローカルで `pnpm db:migrate && pnpm ai:embed && pnpm build`
       # をまとめて流す運用 (溜まったときに手動)。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ pnpm json:extract-urls          # Extract URLs from tweets for /urls page
 pnpm json:remove-duplicates     # Remove duplicate tweets from processed data
 pnpm json:remove-raw-duplicates # Remove duplicate files from raw S3 data
 pnpm json:build-activity        # Build activity data for recent activity graph
+pnpm json:build-garden          # Build トップ「讚の庭」桜バナー用 stats (今月集計 → public/garden-stats.json)
 pnpm json:process-archive       # Process Twitter archive files (like-twitter-*.js)
 pnpm json:fetch-archive         # Fetch tweet data for archive tweets
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "json:remove-duplicates": "tsx src/scripts/remove-duplicate-tweets.ts",
     "json:remove-raw-duplicates": "tsx src/scripts/remove-duplicate-raw-likes.ts",
     "json:build-activity": "tsx src/scripts/build-activity-data.ts",
+    "json:build-garden": "tsx src/scripts/build-garden-stats.ts",
     "json:process-archive": "tsx src/scripts/process-archive-likes.ts",
     "json:fetch-archive": "tsx src/scripts/fetch-archive-tweets.ts",
     "json:build-algolia": "tsx -r dotenv/config src/scripts/build-algolia-index.ts",

--- a/public/garden-stats.json
+++ b/public/garden-stats.json
@@ -1,0 +1,346 @@
+{
+  "current": "2026-06",
+  "generatedAt": "2026-06-06T06:27:44.219Z",
+  "months": {
+    "2024-11": {
+      "elapsedDays": 30,
+      "totalLikes": 269,
+      "categoryWeights": [
+        4,
+        55,
+        3,
+        5,
+        122,
+        16,
+        19,
+        16,
+        5,
+        16,
+        0
+      ]
+    },
+    "2024-12": {
+      "elapsedDays": 31,
+      "totalLikes": 531,
+      "categoryWeights": [
+        25,
+        149,
+        13,
+        16,
+        179,
+        27,
+        49,
+        19,
+        16,
+        37,
+        0
+      ]
+    },
+    "2025-01": {
+      "elapsedDays": 31,
+      "totalLikes": 348,
+      "categoryWeights": [
+        21,
+        72,
+        10,
+        13,
+        118,
+        18,
+        32,
+        12,
+        11,
+        36,
+        2
+      ]
+    },
+    "2025-02": {
+      "elapsedDays": 28,
+      "totalLikes": 357,
+      "categoryWeights": [
+        41,
+        63,
+        9,
+        6,
+        141,
+        22,
+        18,
+        10,
+        10,
+        30,
+        5
+      ]
+    },
+    "2025-03": {
+      "elapsedDays": 31,
+      "totalLikes": 300,
+      "categoryWeights": [
+        84,
+        72,
+        4,
+        15,
+        49,
+        17,
+        18,
+        12,
+        9,
+        20,
+        0
+      ]
+    },
+    "2025-04": {
+      "elapsedDays": 30,
+      "totalLikes": 320,
+      "categoryWeights": [
+        56,
+        77,
+        11,
+        21,
+        46,
+        47,
+        25,
+        10,
+        6,
+        18,
+        3
+      ]
+    },
+    "2025-05": {
+      "elapsedDays": 31,
+      "totalLikes": 228,
+      "categoryWeights": [
+        50,
+        41,
+        5,
+        17,
+        56,
+        12,
+        14,
+        5,
+        6,
+        21,
+        0
+      ]
+    },
+    "2025-06": {
+      "elapsedDays": 30,
+      "totalLikes": 417,
+      "categoryWeights": [
+        134,
+        74,
+        10,
+        18,
+        58,
+        28,
+        35,
+        10,
+        15,
+        34,
+        1
+      ]
+    },
+    "2025-07": {
+      "elapsedDays": 31,
+      "totalLikes": 268,
+      "categoryWeights": [
+        44,
+        67,
+        5,
+        18,
+        37,
+        25,
+        24,
+        9,
+        13,
+        25,
+        0
+      ]
+    },
+    "2025-08": {
+      "elapsedDays": 31,
+      "totalLikes": 291,
+      "categoryWeights": [
+        46,
+        69,
+        5,
+        15,
+        31,
+        18,
+        40,
+        12,
+        12,
+        33,
+        5
+      ]
+    },
+    "2025-09": {
+      "elapsedDays": 30,
+      "totalLikes": 213,
+      "categoryWeights": [
+        45,
+        59,
+        5,
+        14,
+        11,
+        31,
+        13,
+        6,
+        13,
+        15,
+        0
+      ]
+    },
+    "2025-10": {
+      "elapsedDays": 31,
+      "totalLikes": 179,
+      "categoryWeights": [
+        17,
+        39,
+        1,
+        19,
+        14,
+        20,
+        19,
+        8,
+        17,
+        24,
+        0
+      ]
+    },
+    "2025-11": {
+      "elapsedDays": 30,
+      "totalLikes": 98,
+      "categoryWeights": [
+        6,
+        22,
+        4,
+        15,
+        14,
+        10,
+        9,
+        9,
+        4,
+        4,
+        0
+      ]
+    },
+    "2025-12": {
+      "elapsedDays": 31,
+      "totalLikes": 179,
+      "categoryWeights": [
+        17,
+        34,
+        16,
+        17,
+        33,
+        9,
+        17,
+        9,
+        9,
+        17,
+        0
+      ]
+    },
+    "2026-01": {
+      "elapsedDays": 31,
+      "totalLikes": 152,
+      "categoryWeights": [
+        22,
+        14,
+        7,
+        10,
+        27,
+        11,
+        12,
+        8,
+        6,
+        31,
+        3
+      ]
+    },
+    "2026-02": {
+      "elapsedDays": 28,
+      "totalLikes": 112,
+      "categoryWeights": [
+        13,
+        5,
+        2,
+        7,
+        11,
+        12,
+        11,
+        6,
+        4,
+        37,
+        4
+      ]
+    },
+    "2026-03": {
+      "elapsedDays": 31,
+      "totalLikes": 66,
+      "categoryWeights": [
+        7,
+        12,
+        1,
+        3,
+        3,
+        9,
+        8,
+        6,
+        7,
+        9,
+        0
+      ]
+    },
+    "2026-04": {
+      "elapsedDays": 30,
+      "totalLikes": 120,
+      "categoryWeights": [
+        35,
+        15,
+        1,
+        11,
+        13,
+        12,
+        7,
+        7,
+        4,
+        10,
+        4
+      ]
+    },
+    "2026-05": {
+      "elapsedDays": 31,
+      "totalLikes": 326,
+      "categoryWeights": [
+        118,
+        38,
+        4,
+        25,
+        20,
+        17,
+        14,
+        7,
+        18,
+        55,
+        9
+      ]
+    },
+    "2026-06": {
+      "elapsedDays": 6,
+      "totalLikes": 84,
+      "categoryWeights": [
+        11,
+        23,
+        5,
+        3,
+        3,
+        10,
+        9,
+        0,
+        6,
+        13,
+        1
+      ]
+    }
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,11 @@ export const dynamic = 'force-static';
 export const revalidate = false;
 
 import path from 'path';
-import { readdir } from 'fs/promises';
+import { readdir, readFile } from 'fs/promises';
 import { cache } from 'react';
 import { getDb } from '@/lib/db';
 import { HomeTabs } from '@/components/home-tabs';
+import type { GardenData, MonthStats } from '@/components/garden-top-banner';
 import type { DateInfo } from '@/types/like';
 
 const getAllDates = cache(async (): Promise<DateInfo[]> => {
@@ -142,11 +143,52 @@ const getHomeInsights = cache(async (): Promise<HomeInsightsData> => {
   return { last30, prev30, hotCategories, topUsers, monthly };
 });
 
+// 「讚の庭」バナー用の月別 stats。Actions が public/garden-stats.json を毎日更新する。
+// 無い / 壊れている場合は穏当なフォールバックで描画（ビルドは落とさない）。
+const getGardenData = cache(async (): Promise<GardenData> => {
+  const now = new Date();
+  const current = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const fallback: GardenData = {
+    current,
+    months: {
+      [current]: {
+        elapsedDays: now.getDate(),
+        totalLikes: 0,
+        categoryWeights: new Array(11).fill(0),
+      },
+    },
+  };
+  try {
+    const file = path.join(process.cwd(), 'public', 'garden-stats.json');
+    const parsed = JSON.parse(await readFile(file, 'utf-8'));
+    if (!parsed.months || typeof parsed.months !== 'object') return fallback;
+    const months: Record<string, MonthStats> = {};
+    for (const [ym, raw] of Object.entries<Record<string, unknown>>(
+      parsed.months,
+    )) {
+      months[ym] = {
+        elapsedDays: Number(raw.elapsedDays) || 1,
+        totalLikes: Number(raw.totalLikes) || 0,
+        categoryWeights: Array.isArray(raw.categoryWeights)
+          ? raw.categoryWeights.map(Number)
+          : new Array(11).fill(0),
+      };
+    }
+    return {
+      current: typeof parsed.current === 'string' ? parsed.current : current,
+      months,
+    };
+  } catch {
+    return fallback;
+  }
+});
+
 export default async function Home() {
-  const [allDates, categoryData, insights] = await Promise.all([
+  const [allDates, categoryData, insights, gardenData] = await Promise.all([
     getAllDates(),
     getCategoryCounts(),
     getHomeInsights(),
+    getGardenData(),
   ]);
 
   return (
@@ -155,6 +197,7 @@ export default async function Home() {
       categoryCounts={categoryData.counts}
       totalCount={categoryData.total}
       insights={insights}
+      gardenData={gardenData}
     />
   );
 }

--- a/src/components/garden-top-banner.tsx
+++ b/src/components/garden-top-banner.tsx
@@ -1,0 +1,336 @@
+'use client';
+
+/**
+ * GardenTopBanner — トップに置く「讚の庭」バナー。
+ * stats は Server Component（page.tsx）が public/garden-stats.json を読んで
+ * props で渡す（fetch 不要・レイアウトシフト無し）。
+ * トップのカレンダーで月を選ぶと、その月の stats に切り替わる（HomeTabs が制御）。
+ */
+import { HelpCircle, ChevronLeft, ChevronRight } from 'lucide-react';
+import ZanNoNiwa, { verdict } from './zan-no-niwa';
+import { Popover, PopoverTrigger, PopoverContent } from './ui/popover';
+import { CATEGORIES } from '@/data/categories';
+
+/** 1 ヶ月分の庭 stats */
+export interface MonthStats {
+  /** その月の経過日数（過去月は月の日数＝満成長、当月は今日） */
+  elapsedDays: number;
+  /** その月のいいね総数 */
+  totalLikes: number;
+  /** CATEGORIES 順のカテゴリ別件数 */
+  categoryWeights: number[];
+}
+
+/** 全月分 + 当月キー */
+export interface GardenData {
+  current: string; // 'YYYY-MM'
+  months: Record<string, MonthStats>;
+}
+
+/** '2026-06' → '6月' */
+function monthLabel(month: string): string {
+  const m = month.split('-')[1];
+  return m ? `${Number(m)}月` : '今月';
+}
+
+/** カテゴリ割合の上位を取り出す */
+function topCategories(weights: number[], n: number) {
+  const sum = weights.reduce((a, b) => a + b, 0);
+  if (sum <= 0) return [];
+  return weights
+    .map((w, i) => ({ cat: CATEGORIES[i], w, pct: Math.round((w / sum) * 100) }))
+    .filter((d) => d.cat && d.w > 0)
+    .sort((a, b) => b.w - a.w)
+    .slice(0, n);
+}
+
+/** 木エリア左右の月送りボタン */
+function MonthNavButton({
+  side,
+  disabled,
+  onClick,
+}: {
+  side: 'left' | 'right';
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  const Icon = side === 'left' ? ChevronLeft : ChevronRight;
+  return (
+    <button
+      type="button"
+      aria-label={side === 'left' ? '前の月へ' : '次の月へ'}
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        position: 'absolute',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        [side]: -2,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 28,
+        height: 40,
+        padding: 0,
+        border: 0,
+        background: 'transparent',
+        color: 'var(--text-3)',
+        opacity: disabled ? 0.25 : 0.7,
+        cursor: disabled ? 'default' : 'pointer',
+        transition: 'opacity .15s',
+      }}
+      onMouseEnter={(e) => {
+        if (!disabled) e.currentTarget.style.opacity = '1';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.opacity = disabled ? '0.25' : '0.7';
+      }}
+    >
+      <Icon size={22} strokeWidth={1.75} />
+    </button>
+  );
+}
+
+export function GardenTopBanner({
+  stats,
+  monthKey,
+  canPrev,
+  canNext,
+  onPrev,
+  onNext,
+}: {
+  stats: MonthStats;
+  monthKey: string;
+  canPrev: boolean;
+  canNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  const v = verdict(stats.elapsedDays, stats.totalLikes);
+  const label = monthLabel(monthKey);
+  const tops = topCategories(stats.categoryWeights, 3);
+
+  return (
+    <section
+      aria-label="今月のいいねで育つ庭"
+      style={{ position: 'relative', width: '100%' }}
+    >
+      <MonthNavButton side="left" disabled={!canPrev} onClick={onPrev} />
+      <MonthNavButton side="right" disabled={!canNext} onClick={onNext} />
+
+      <ZanNoNiwa
+        elapsedDays={stats.elapsedDays}
+        totalLikes={stats.totalLikes}
+        categoryWeights={stats.categoryWeights}
+        categoryColor
+      />
+
+      {/* 判定ラベル（右上） */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 8,
+          right: 4,
+          textAlign: 'right',
+          pointerEvents: 'none',
+          maxWidth: '70%',
+        }}
+      >
+        <div style={{ fontSize: 12, fontWeight: 700, color: v.color }}>
+          {v.label}
+        </div>
+        <div
+          className="font-mono"
+          style={{
+            fontSize: 11,
+            color: 'var(--text-3)',
+            fontVariantNumeric: 'tabular-nums',
+          }}
+        >
+          {label} {stats.totalLikes.toLocaleString()} いいね
+        </div>
+      </div>
+
+      {/* カテゴリ割合（上位3）— 植木の下・右詰め */}
+      {tops.length > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'flex-end',
+            gap: '2px 10px',
+            marginTop: 2,
+            paddingRight: 4,
+          }}
+        >
+          {tops.map((d) => (
+            <span
+              key={d.cat.name}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                fontSize: 10.5,
+                color: 'var(--text-2)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              <span
+                style={{
+                  width: 7,
+                  height: 7,
+                  borderRadius: '50%',
+                  background: `oklch(73% 0.18 ${d.cat.hue})`,
+                }}
+              />
+              {d.cat.short}{' '}
+              <span
+                className="font-mono"
+                style={{
+                  color: 'var(--text-3)',
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
+                {d.pct}%
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* ヘルプ（左上）— 木の見方とカテゴリ色の説明 */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label="この木の説明"
+            style={{
+              position: 'absolute',
+              top: 4,
+              left: 0,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 26,
+              height: 26,
+              padding: 0,
+              border: 0,
+              background: 'transparent',
+              color: 'var(--text-3)',
+              cursor: 'pointer',
+            }}
+          >
+            <HelpCircle size={16} strokeWidth={1.75} />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-72"
+          style={{
+            // Liquid Glass — 半透明 + 背景ブラー + 光るリム
+            background:
+              'linear-gradient(135deg, rgba(255,255,255,0.13) 0%, rgba(255,255,255,0.05) 38%, rgba(255,255,255,0.02) 100%), rgba(18,20,26,0.42)',
+            backdropFilter: 'blur(18px) saturate(180%)',
+            WebkitBackdropFilter: 'blur(18px) saturate(180%)',
+            border: '1px solid rgba(255,255,255,0.16)',
+            boxShadow:
+              '0 12px 40px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.25), inset 0 0 0 0.5px rgba(255,255,255,0.06)',
+            color: 'var(--text-1)',
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div
+              style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-0)' }}
+            >
+              讚の庭 — その月のいいねで育つ桜
+            </div>
+            <ul
+              style={{
+                margin: 0,
+                paddingLeft: 16,
+                fontSize: 11.5,
+                lineHeight: 1.7,
+                color: 'var(--text-2)',
+              }}
+            >
+              <li>
+                <b style={{ color: 'var(--text-1)' }}>幹・枝</b> … その月の経過日数で育つ（1日目=苗 → 月末=完成）
+              </li>
+              <li>
+                <b style={{ color: 'var(--text-1)' }}>花の数</b> … その月のいいね数（多いほど満開）
+              </li>
+              <li>
+                <b style={{ color: 'var(--text-1)' }}>花の色</b> … いいねしたカテゴリ（下の凡例）
+              </li>
+              <li>
+                <b style={{ color: 'var(--text-1)' }}>右上の判定</b> … 1日あたりのペースで大木⇄枯れ木
+              </li>
+              <li>カレンダーで月を選ぶと、その月の木に変わります</li>
+              <li>木をタップすると揺れて花びらが散ります</li>
+            </ul>
+
+            <div
+              style={{
+                marginTop: 2,
+                paddingTop: 8,
+                borderTop: '0.5px solid var(--line-soft, #2a2d33)',
+              }}
+            >
+              <div
+                className="font-mono"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  color: 'var(--text-3)',
+                  marginBottom: 6,
+                }}
+              >
+                花の色 = カテゴリ
+              </div>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 1fr',
+                  gap: '4px 10px',
+                }}
+              >
+                {CATEGORIES.map((c) => (
+                  <div
+                    key={c.name}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      fontSize: 11,
+                      color: 'var(--text-2)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        flex: '0 0 auto',
+                        width: 8,
+                        height: 8,
+                        borderRadius: '50%',
+                        background: `oklch(73% 0.18 ${c.hue})`,
+                      }}
+                    />
+                    <span
+                      style={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {c.label_ja}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </section>
+  );
+}

--- a/src/components/home-tabs.tsx
+++ b/src/components/home-tabs.tsx
@@ -5,7 +5,13 @@ import Link from 'next/link';
 import { CalendarDays, LayoutGrid, ArrowRight, Search as SearchIcon } from 'lucide-react';
 import { CalendarPicker } from './calendar-picker';
 import { HomeInsights } from './home-insights';
+import {
+  GardenTopBanner,
+  type GardenData,
+  type MonthStats,
+} from './garden-top-banner';
 import { CATEGORIES } from '@/data/categories';
+import { useCalendarStore } from '@/store/calendar-store';
 import type { DateInfo } from '@/types/like';
 import type { HomeInsightsData } from '@/app/page';
 
@@ -16,11 +22,13 @@ export function HomeTabs({
   categoryCounts,
   totalCount,
   insights,
+  gardenData,
 }: {
   allDates: DateInfo[];
   categoryCounts: CategoryCount[];
   totalCount: number;
   insights: HomeInsightsData;
+  gardenData: GardenData;
 }) {
   const [tab, setTab] = useState<'calendar' | 'categories'>('calendar');
   const thumbRef = useRef<HTMLDivElement | null>(null);
@@ -46,8 +54,48 @@ export function HomeTabs({
 
   const countMap = new Map(categoryCounts.map((c) => [c.name, c.count]));
 
+  // ── 讚の庭：カレンダーの表示月に連動して木を切り替える ──
+  const displayMonth = useCalendarStore((s) => s.displayMonth);
+  const setDisplayMonth = useCalendarStore((s) => s.setDisplayMonth);
+  const gardenMonthKey = displayMonth
+    ? `${displayMonth.getFullYear()}-${String(displayMonth.getMonth() + 1).padStart(2, '0')}`
+    : gardenData.current;
+
+  // 月送りの範囲：[最古のデータ月, 当月]
+  const earliestMonthKey =
+    Object.keys(gardenData.months).sort()[0] ?? gardenData.current;
+  const canGardenPrev = gardenMonthKey > earliestMonthKey;
+  const canGardenNext = gardenMonthKey < gardenData.current;
+  const stepGardenMonth = (delta: number) => {
+    const [y, m] = gardenMonthKey.split('-').map(Number);
+    setDisplayMonth(new Date(y, m - 1 + delta, 1));
+  };
+  const gardenStats: MonthStats = gardenData.months[gardenMonthKey] ?? {
+    // データの無い月：過去なら満成長の裸木、当月なら今日まで
+    elapsedDays:
+      gardenMonthKey >= gardenData.current
+        ? (gardenData.months[gardenData.current]?.elapsedDays ?? 1)
+        : new Date(
+            Number(gardenMonthKey.slice(0, 4)),
+            Number(gardenMonthKey.slice(5, 7)),
+            0,
+          ).getDate(),
+    totalLikes: 0,
+    categoryWeights: new Array(CATEGORIES.length).fill(0),
+  };
+
   return (
     <div className="col-28" style={{ padding: '20px 16px 60px', display: 'flex', flexDirection: 'column', gap: 24 }}>
+      {/* 讚の庭バナー — その月のいいねで育つ桜（カレンダーの表示月に連動） */}
+      <GardenTopBanner
+        stats={gardenStats}
+        monthKey={gardenMonthKey}
+        canPrev={canGardenPrev}
+        canNext={canGardenNext}
+        onPrev={() => stepGardenMonth(-1)}
+        onNext={() => stepGardenMonth(1)}
+      />
+
       {/* Hero stat */}
       <div className="flex flex-col gap-1.5" style={{ padding: '8px 2px 0' }}>
         <div className="zk-section-label">archive</div>

--- a/src/components/zan-no-niwa.tsx
+++ b/src/components/zan-no-niwa.tsx
@@ -1,0 +1,395 @@
+/**
+ * ZanNoNiwa — 「讚の庭」トップアニメ
+ * ---------------------------------------------------------------
+ * 集讚館（z.xiemen.me）のトップに置く、直近30日のいいねで育つ桜。
+ *   - 幹/枝   = 経過日数（elapsedDays / 30）で強制成長
+ *   - 開花量  = いいね総数（totalLikes）で間引き（少=枯れ木 / 多=満開）
+ *   - 花の色  = カテゴリ（categories の hue）。OFF なら桃×金
+ *   - 活力    = いいね/日 → 月末の判定（大木⇄枯れ木）と色の鮮やかさ
+ *   - クリック= その地点を起点に枝が揺れ、花びらが散る
+ *
+ * design_handoff_zan_no_niwa/reference-implementation/ZanNoNiwa.jsx を
+ * 本プロジェクト（TypeScript / app router）の規約へ写したもの。
+ * 数値（しきい値・配色）はすべて先頭の定数に集約。
+ */
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+// ── 実サイト src/data/categories.ts の hue をそのまま（GARDEN_CATS 順）──
+export const GARDEN_CATS = [
+  { name: 'tech-ai', hue: 250 },
+  { name: 'programming', hue: 290 },
+  { name: 'design', hue: 320 },
+  { name: 'product-business', hue: 30 },
+  { name: 'art-creative', hue: 350 },
+  { name: 'gaming', hue: 180 },
+  { name: 'culture-entertainment', hue: 70 },
+  { name: 'science-learning', hue: 200 },
+  { name: 'news-society', hue: 20 },
+  { name: 'lifestyle', hue: 130 },
+  { name: 'other', hue: 240 },
+] as const;
+
+// ── チューニング定数（仕様の唯一の真実）──
+const CFG = {
+  W: 860,
+  H: 250, // キャンバス論理サイズ
+  POT_HUE: '228,87,46', // 鉢の色（朱）
+  C_PINK: '#ff5d97', // 桜の桃
+  C_GOLD: '#e8b84b', // 金しべ
+  DAYS_IN_CYCLE: 30, // 成長の正規化（経過日数 / 30）。月末で樹形完成
+  DEPTH_MIN: 3,
+  DEPTH_MAX: 8, // 経過日数による枝の深さ
+  TRUNK_MIN: 26,
+  TRUNK_GROW: 30,
+  SWAY: 0.18, // 風の基本振れ
+  // ── 以下 2 つは実データ（月別 65〜325 件 / 月）で較正済み ──
+  BLOOM_FULL: 320, // 今月の総数がこの値で開花率 100%（≒最盛月で満開）
+  PACE_FOR_GREAT: 10, // いいね/日 がこの値で「大木」(活力=1)。月 ≒300 件で豊作
+};
+
+// ── 純関数ヘルパ ──
+const clamp = (v: number, a: number, b: number) => (v < a ? a : v > b ? b : v);
+const ease = (t: number) =>
+  t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+
+function hashU(id: number): number {
+  let x = (id * 2654435761) >>> 0;
+  x ^= x >>> 15;
+  x = Math.imul(x, 2246822519);
+  x ^= x >>> 13;
+  return (x >>> 0) / 4294967296;
+}
+
+function pickCat(u: number, weights: number[], sum: number): number {
+  let acc = 0;
+  for (let k = 0; k < weights.length; k++) {
+    acc += weights[k] / sum;
+    if (u <= acc) return k;
+  }
+  return weights.length - 1;
+}
+
+function heartPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  s: number,
+  rot = 0,
+) {
+  ctx.save();
+  ctx.translate(x, y);
+  if (rot) ctx.rotate(rot);
+  ctx.scale(s / 16, s / 16);
+  ctx.beginPath();
+  ctx.moveTo(0, 4.6);
+  ctx.bezierCurveTo(-7.4, -2.2, -6.2, -10.4, 0, -5.4);
+  ctx.bezierCurveTo(6.2, -10.4, 7.4, -2.2, 0, 4.6);
+  ctx.closePath();
+  ctx.restore();
+}
+
+type BlossomPt = [number, number, number]; // [x, y, id]
+
+interface Petal {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  s: number;
+  a: number;
+  hue: number | null;
+}
+
+interface ZanState {
+  elapsedDays: number;
+  totalLikes: number;
+  categoryWeights: number[];
+  categoryColor: boolean;
+}
+
+export interface ZanNoNiwaProps {
+  /** 経過日数（1..30）。枝の深さ・幹長を決める */
+  elapsedDays?: number;
+  /** 直近30日のいいね総数。開花量を決める */
+  totalLikes?: number;
+  /** 11要素のカテゴリ件数（GARDEN_CATS 順）。花色の比率 */
+  categoryWeights?: number[];
+  /** true=カテゴリ色 / false=桃×金 */
+  categoryColor?: boolean;
+  /** 表示幅（CSS px）。未指定なら親コンテナ幅に追従（width:100%） */
+  width?: number;
+}
+
+export default function ZanNoNiwa({
+  elapsedDays = 30,
+  totalLikes = 320,
+  categoryWeights = [30, 16, 8, 6, 5, 2, 9, 5, 4, 13, 2],
+  categoryColor = true,
+  width,
+}: ZanNoNiwaProps) {
+  const ref = useRef<HTMLCanvasElement>(null);
+  // 最新 props を ref 経由で描画ループへ渡す（再マウントせずに反映）
+  const stateRef = useRef<ZanState>({
+    elapsedDays,
+    totalLikes,
+    categoryWeights,
+    categoryColor,
+  });
+  stateRef.current = { elapsedDays, totalLikes, categoryWeights, categoryColor };
+
+  useEffect(() => {
+    const { W, H } = CFG;
+    const cv = ref.current;
+    if (!cv) return;
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    cv.width = W * dpr;
+    cv.height = H * dpr;
+    const ctx = cv.getContext('2d');
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const baseX = W / 2;
+    const baseY = H - 26;
+    const petals: Petal[] = [];
+    let raf = 0;
+    let last = performance.now();
+    let t = 0;
+    let shake: { x: number; y: number; t0: number; spawned: boolean } | null =
+      null;
+    let shAge = 999;
+    let shEnv = 0;
+    let blossomPts: BlossomPt[] = [];
+    const reduce = window.matchMedia?.(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+
+    function onDown(e: PointerEvent) {
+      if (!cv) return;
+      const r = cv.getBoundingClientRect();
+      shake = {
+        x: (e.clientX - r.left) * (W / r.width),
+        y: (e.clientY - r.top) * (H / r.height),
+        t0: t,
+        spawned: false,
+      };
+    }
+    cv.addEventListener('pointerdown', onDown);
+
+    function branch(
+      x: number,
+      y: number,
+      ang: number,
+      len: number,
+      depth: number,
+      maxDepth: number,
+      sway: number,
+      id: number,
+    ) {
+      if (depth > maxDepth || len < 4) {
+        if (depth >= maxDepth - 1) blossomPts.push([x, y, id]);
+        return;
+      }
+      let sw = Math.sin(t * 1.1 + depth * 0.7) * sway * (depth / maxDepth);
+      if (shEnv > 0.002 && shake) {
+        const prox = clamp(1 - Math.hypot(x - shake.x, y - shake.y) / 300, 0, 1);
+        sw +=
+          shEnv *
+          0.6 *
+          prox *
+          Math.sin(shAge * 13) *
+          (0.3 + depth / maxDepth) *
+          Math.sign(x - shake.x || 1);
+      }
+      const a = ang + sw;
+      const x2 = x + Math.cos(a) * len;
+      const y2 = y + Math.sin(a) * len;
+      ctx!.strokeStyle = `rgba(150,120,95,${0.55 + 0.4 * (1 - depth / maxDepth)})`;
+      ctx!.lineWidth = Math.max(1, (maxDepth - depth) * 1.5);
+      ctx!.lineCap = 'round';
+      ctx!.beginPath();
+      ctx!.moveTo(x, y);
+      ctx!.lineTo(x2, y2);
+      ctx!.stroke();
+      const spread = 0.5 + 0.12 * Math.sin(depth);
+      branch(x2, y2, a - spread, len * 0.76, depth + 1, maxDepth, sway, id * 4 + 1);
+      branch(x2, y2, a + spread, len * 0.72, depth + 1, maxDepth, sway, id * 4 + 2);
+      if (depth % 2 === 0)
+        branch(x2, y2, a + 0.04, len * 0.6, depth + 2, maxDepth, sway, id * 4 + 3);
+    }
+
+    function mkPetal(
+      p: BlossomPt,
+      S: ZanState,
+      weights: number[],
+      sum: number,
+    ): Petal {
+      return {
+        x: p[0],
+        y: p[1],
+        vx: (Math.random() - 0.5) * 0.7,
+        vy: -0.3 - Math.random() * 0.45,
+        r: 0,
+        s: 5 + Math.random() * 4,
+        a: 1,
+        hue: S.categoryColor
+          ? GARDEN_CATS[pickCat(hashU(p[2]), weights, sum)].hue
+          : null,
+      };
+    }
+
+    function draw() {
+      const S = stateRef.current;
+      const day = clamp(S.elapsedDays, 0, CFG.DAYS_IN_CYCLE);
+      const total = Math.max(0, S.totalLikes);
+      const weights = S.categoryWeights;
+      const sum = weights.reduce((a, b) => a + b, 0) || 1;
+
+      ctx!.clearRect(0, 0, W, H);
+      // 地面
+      ctx!.strokeStyle = 'rgba(255,255,255,.10)';
+      ctx!.lineWidth = 1.5;
+      ctx!.beginPath();
+      ctx!.moveTo(60, baseY + 8);
+      ctx!.lineTo(W - 60, baseY + 8);
+      ctx!.stroke();
+      // 鉢
+      ctx!.fillStyle = `rgba(${CFG.POT_HUE},.85)`;
+      ctx!.beginPath();
+      ctx!.roundRect(baseX - 34, baseY + 8, 68, 20, 3);
+      ctx!.fill();
+      ctx!.fillStyle = 'rgba(0,0,0,.25)';
+      ctx!.beginPath();
+      ctx!.roundRect(baseX - 38, baseY + 4, 76, 8, 3);
+      ctx!.fill();
+
+      shAge = shake ? t - shake.t0 : 999;
+      shEnv = shake ? Math.exp(-shAge * 2.6) : 0;
+      if (shake && shAge > 2.6) shake = null;
+
+      const eased = ease(clamp(day / CFG.DAYS_IN_CYCLE, 0, 1));
+      const maxDepth =
+        CFG.DEPTH_MIN + Math.round(eased * (CFG.DEPTH_MAX - CFG.DEPTH_MIN));
+      const trunk = CFG.TRUNK_MIN + eased * CFG.TRUNK_GROW;
+      blossomPts = [];
+      branch(baseX, baseY + 8, -Math.PI / 2, trunk, 0, maxDepth, reduce ? 0 : CFG.SWAY, 1);
+
+      const bloom = eased;
+      const bloomFrac = clamp(total / CFG.BLOOM_FULL, 0, 1);
+      const blooming: BlossomPt[] = [];
+      for (let i = 0; i < blossomPts.length; i++) {
+        const p = blossomPts[i];
+        const id = p[2];
+        if (hashU(id ^ 0x9e37) > bloomFrac) continue;
+        blooming.push(p);
+        const s = (6 + 4 * Math.sin(t * 2 + i)) * (0.4 + 0.6 * bloom);
+        if (s < 1) continue;
+        heartPath(ctx!, p[0], p[1], s);
+        ctx!.fillStyle = S.categoryColor
+          ? `oklch(73% 0.18 ${GARDEN_CATS[pickCat(hashU(id), weights, sum)].hue})`
+          : hashU(id ^ 0x55) < 0.25
+            ? CFG.C_GOLD
+            : CFG.C_PINK;
+        ctx!.globalAlpha = 0.5 + 0.5 * bloom;
+        ctx!.fill();
+        ctx!.globalAlpha = 1;
+      }
+
+      // クリックで近くの花を散らす
+      if (shake && !shake.spawned) {
+        shake.spawned = true;
+        for (const p of blooming) {
+          if (
+            Math.hypot(p[0] - shake.x, p[1] - shake.y) < 120 &&
+            Math.random() < 0.8
+          )
+            petals.push(mkPetal(p, S, weights, sum));
+        }
+      }
+      // 自然な花吹雪
+      if (!reduce && bloom > 0.5 && Math.random() < 0.06 && blooming.length)
+        petals.push(
+          mkPetal(
+            blooming[(Math.random() * blooming.length) | 0],
+            S,
+            weights,
+            sum,
+          ),
+        );
+
+      for (let i = petals.length - 1; i >= 0; i--) {
+        const p = petals[i];
+        p.x += p.vx;
+        p.y += p.vy;
+        p.vy += 0.004;
+        p.r += 0.04;
+        p.a -= 0.006;
+        if (p.a <= 0) {
+          petals.splice(i, 1);
+          continue;
+        }
+        ctx!.save();
+        ctx!.translate(p.x, p.y);
+        ctx!.rotate(p.r);
+        heartPath(ctx!, 0, 0, p.s);
+        ctx!.fillStyle = p.hue == null ? CFG.C_PINK : `oklch(73% 0.18 ${p.hue})`;
+        ctx!.globalAlpha = p.a;
+        ctx!.fill();
+        ctx!.restore();
+        ctx!.globalAlpha = 1;
+      }
+    }
+
+    function loop(now: number) {
+      t += Math.min(0.05, (now - last) / 1000);
+      last = now;
+      draw();
+      raf = requestAnimationFrame(loop);
+    }
+    draw();
+    raf = requestAnimationFrame(loop);
+    return () => {
+      cancelAnimationFrame(raf);
+      cv.removeEventListener('pointerdown', onDown);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={ref}
+      role="img"
+      aria-label="今月のいいねで育つ桜の木"
+      style={{
+        display: 'block',
+        width: width ?? '100%',
+        height: width ? (width / CFG.W) * CFG.H : 'auto',
+        aspectRatio: width ? undefined : `${CFG.W} / ${CFG.H}`,
+        cursor: 'pointer',
+      }}
+    />
+  );
+}
+
+/** 月末判定（大木⇄枯れ木）— バナーの文言に使う */
+export function verdict(
+  elapsedDays: number,
+  totalLikes: number,
+): { label: string; color: string; vit: number } {
+  const vit = clamp(
+    totalLikes / Math.max(1, elapsedDays) / CFG.PACE_FOR_GREAT,
+    0,
+    1,
+  );
+  if (elapsedDays >= 28 && vit >= 0.9)
+    return { label: '大木 — 今月は豊作', color: '#7fd6a0', vit };
+  if (vit >= 0.85) return { label: 'のびやかな大木へ', color: '#7fd6a0', vit };
+  if (vit >= 0.6) return { label: '健やかに茂る', color: '#bcd98a', vit };
+  if (vit >= 0.32) return { label: 'ほどほどの繁り', color: '#e8b84b', vit };
+  return {
+    label: elapsedDays >= 28 ? '枯れ木 — 今月は不作' : '枯れ気味',
+    color: '#e08a5a',
+    vit,
+  };
+}

--- a/src/scripts/build-garden-stats.ts
+++ b/src/scripts/build-garden-stats.ts
@@ -1,0 +1,185 @@
+/**
+ * build-garden-stats.ts — GitHub Actions の「いいね取り込み」ジョブ末尾で実行。
+ * トップの「讚の庭」桜コンポーネント（ZanNoNiwa）に渡す JSON を書き出す。
+ *
+ *   出力: public/garden-stats.json
+ *   {
+ *     "current": "2026-06",         // 当月（Asia/Tokyo）
+ *     "generatedAt": "2026-06-06T...",
+ *     "months": {
+ *       "2025-07": { "elapsedDays": 31, "totalLikes": 267, "categoryWeights": [..11..] },
+ *       ...
+ *       "2026-06": { "elapsedDays": 6,  "totalLikes": 84,  "categoryWeights": [..11..] }
+ *     }
+ *   }
+ *
+ * ★ 月（カレンダー月）ごとに集計し、トップのカレンダーで月を選ぶと木がその月の姿に
+ *   なる。過去の完了月は elapsedDays = その月の日数（＝満成長）、当月は今日の日付。
+ *
+ * データ源の使い分け（このプロジェクトの 2 段階パイプラインに合わせる）:
+ *   - totalLikes … 日別 JSON（src/content/likes/**.json）から月別集計。
+ *       Actions が毎日 enrich する最新源なので、取り込んだ分だけ当月の木が育つ。
+ *   - categoryWeights … SQLite（data/likes.db）の parent_category から月別集計。
+ *       カテゴリ分類はローカル手動運用なので JSON には載らない。花色の比率を決める
+ *       だけなので、未分類の最新ツイートは色に寄与しない（graceful degrade）。
+ *       ※ source='ifttt' に限定。archive（旧Twitterエクスポートの一括取り込み）は
+ *         liked_at がインポート月に固まるため、月別集計に混ぜると歪む。日別 JSON
+ *         （= ifttt のみ）の totalLikes と母集団を揃える意味でも ifttt 限定。
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { toZonedTime, format } from 'date-fns-tz';
+import { getDb } from '../lib/db';
+import { CATEGORY_NAMES } from '../data/categories';
+
+const TZ = 'Asia/Tokyo';
+
+interface DailyLike {
+  liked_at?: string;
+}
+interface DailyFile {
+  body?: DailyLike[];
+}
+interface MonthStats {
+  elapsedDays: number;
+  totalLikes: number;
+  categoryWeights: number[];
+}
+
+/** 'YYYY-MM' のその月の日数 */
+function daysInMonth(month: string): number {
+  const [y, m] = month.split('-').map(Number);
+  return new Date(y, m, 0).getDate();
+}
+
+/** src/content/likes/YYYY/MM/DD.json を再帰的に集める（glob 非依存）。 */
+function collectDailyFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/^\d{2}\.json$/.test(entry.name)) out.push(full);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/** 日別 JSON から月別（'YYYY-MM' → 件数）のいいね総数を数える。 */
+function countLikesByMonth(): Map<string, number> {
+  const totals = new Map<string, number>();
+  const contentDir = path.join(process.cwd(), 'src/content/likes');
+  if (!fs.existsSync(contentDir)) return totals;
+  for (const file of collectDailyFiles(contentDir)) {
+    let parsed: DailyFile;
+    try {
+      parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(parsed.body)) continue;
+    for (const like of parsed.body) {
+      // liked_at は Asia/Tokyo の壁時計（タイムゾーン無し）。'YYYY-MM' 前方一致。
+      if (typeof like.liked_at !== 'string') continue;
+      const ym = like.liked_at.slice(0, 7);
+      if (!/^\d{4}-\d{2}$/.test(ym)) continue;
+      totals.set(ym, (totals.get(ym) ?? 0) + 1);
+    }
+  }
+  return totals;
+}
+
+/** SQLite からカテゴリ別件数を月別（'YYYY-MM' → CATEGORY_NAMES 順 weights）で返す。 */
+async function loadCategoryWeightsByMonth(): Promise<Map<string, number[]>> {
+  const byMonth = new Map<string, number[]>();
+  try {
+    const db = getDb();
+    const res = await db.execute(
+      `SELECT strftime('%Y-%m', liked_at) AS ym,
+              parent_category AS name,
+              COUNT(*) AS n
+       FROM likes
+       WHERE private = 0 AND notfound = 0
+         AND parent_category IS NOT NULL
+         AND source = 'ifttt'
+       GROUP BY ym, parent_category`,
+    );
+    for (const row of res.rows) {
+      const ym = String(row.ym ?? '');
+      if (!/^\d{4}-\d{2}$/.test(ym)) continue;
+      let weights = byMonth.get(ym);
+      if (!weights) {
+        weights = new Array(CATEGORY_NAMES.length).fill(0);
+        byMonth.set(ym, weights);
+      }
+      const idx = CATEGORY_NAMES.indexOf(String(row.name));
+      const target = idx >= 0 ? idx : CATEGORY_NAMES.length - 1; // 未知は other
+      weights[target] += Number(row.n ?? 0);
+    }
+  } catch (e) {
+    console.warn(
+      'garden-stats: SQLite からカテゴリを取得できませんでした（花色は均一になります）:',
+      e instanceof Error ? e.message : e,
+    );
+  }
+  return byMonth;
+}
+
+async function main() {
+  const nowTokyo = toZonedTime(new Date(), TZ);
+  const current = format(nowTokyo, 'yyyy-MM', { timeZone: TZ });
+  const today = nowTokyo.getDate();
+
+  const [totalsByMonth, weightsByMonth] = await Promise.all([
+    Promise.resolve(countLikesByMonth()),
+    loadCategoryWeightsByMonth(),
+  ]);
+
+  // いいねがある全月（JSON 由来）＋カテゴリだけある月も拾う
+  const months = new Set<string>([
+    ...totalsByMonth.keys(),
+    ...weightsByMonth.keys(),
+  ]);
+
+  const monthsOut: Record<string, MonthStats> = {};
+  for (const ym of [...months].sort()) {
+    if (ym > current) continue; // 未来月は出さない
+    monthsOut[ym] = {
+      // 過去の完了月は満成長（その月の日数）、当月は今日まで
+      elapsedDays: ym === current ? today : daysInMonth(ym),
+      totalLikes: totalsByMonth.get(ym) ?? 0,
+      categoryWeights:
+        weightsByMonth.get(ym) ?? new Array(CATEGORY_NAMES.length).fill(0),
+    };
+  }
+
+  // 当月のエントリは必ず用意（今月まだ 0 件でも木が出るように）
+  if (!monthsOut[current]) {
+    monthsOut[current] = {
+      elapsedDays: today,
+      totalLikes: 0,
+      categoryWeights: new Array(CATEGORY_NAMES.length).fill(0),
+    };
+  }
+
+  const stats = {
+    current,
+    generatedAt: new Date().toISOString(),
+    months: monthsOut,
+  };
+
+  const outDir = path.join(process.cwd(), 'public');
+  fs.mkdirSync(outDir, { recursive: true });
+  const out = path.join(outDir, 'garden-stats.json');
+  fs.writeFileSync(out, JSON.stringify(stats, null, 2));
+  console.log(
+    `garden-stats.json written: current=${current}, months=${Object.keys(monthsOut).length}`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
その月のいいねで育つ桜を Canvas で描画してトップに設置。
- 幹/枝は経過日数、開花量は今月のいいね数、花色はカテゴリ hue で決定
- カレンダーの月送りと連動し過去月も観察可能（木エリアの左右ボタンも追加）
- ヘルプ（Liquid Glass 風 popover）とカテゴリ割合（植木下・右詰め）を表示
- 判定しきい値を実データで較正
- build-garden-stats を毎日の取り込み Actions に接続し public/garden-stats.json を月別生成