### PR TITLE
✨ feat: トップに「讚の庭」桜バナーを追加（カレンダー連動）

### DIFF
--- a/src/components/garden-top-banner.tsx
+++ b/src/components/garden-top-banner.tsx
@@ -94,6 +94,7 @@ function MonthNavButton({
 export function GardenTopBanner({
   stats,
   monthKey,
+  isCurrent,
   canPrev,
   canNext,
   onPrev,
@@ -101,12 +102,14 @@ export function GardenTopBanner({
 }: {
   stats: MonthStats;
   monthKey: string;
+  isCurrent: boolean;
   canPrev: boolean;
   canNext: boolean;
   onPrev: () => void;
   onNext: () => void;
 }) {
-  const v = verdict(stats.elapsedDays, stats.totalLikes);
+  // 過去月（完了済み）は確定結果、当月は進行中の予測表現
+  const v = verdict(stats.elapsedDays, stats.totalLikes, !isCurrent);
   const label = monthLabel(monthKey);
   const tops = topCategories(stats.categoryWeights, 3);
 

--- a/src/components/home-tabs.tsx
+++ b/src/components/home-tabs.tsx
@@ -90,6 +90,7 @@ export function HomeTabs({
       <GardenTopBanner
         stats={gardenStats}
         monthKey={gardenMonthKey}
+        isCurrent={gardenMonthKey === gardenData.current}
         canPrev={canGardenPrev}
         canNext={canGardenNext}
         onPrev={() => stepGardenMonth(-1)}

--- a/src/components/zan-no-niwa.tsx
+++ b/src/components/zan-no-niwa.tsx
@@ -372,24 +372,34 @@ export default function ZanNoNiwa({
   );
 }
 
-/** 月末判定（大木⇄枯れ木）— バナーの文言に使う */
+/**
+ * 月の判定（大木⇄枯れ木）— バナーの文言に使う。
+ * @param complete その月が完了済みか（過去月 = true）。
+ *   true なら確定した結果（過去形）、false なら進行中の今月向けの予測表現を返す。
+ */
 export function verdict(
   elapsedDays: number,
   totalLikes: number,
+  complete = false,
 ): { label: string; color: string; vit: number } {
   const vit = clamp(
     totalLikes / Math.max(1, elapsedDays) / CFG.PACE_FOR_GREAT,
     0,
     1,
   );
+  if (complete) {
+    // 完了済みの過去月 — 確定した結果
+    if (vit >= 0.9) return { label: '大木 — 豊作の月', color: '#7fd6a0', vit };
+    if (vit >= 0.85) return { label: 'のびやかな大木', color: '#7fd6a0', vit };
+    if (vit >= 0.6) return { label: '健やかに茂った', color: '#bcd98a', vit };
+    if (vit >= 0.32) return { label: 'ほどほどの繁り', color: '#e8b84b', vit };
+    return { label: '枯れ木 — 不作の月', color: '#e08a5a', vit };
+  }
+  // 進行中の今月 — このペースで向かう先（予測）
   if (elapsedDays >= 28 && vit >= 0.9)
     return { label: '大木 — 今月は豊作', color: '#7fd6a0', vit };
   if (vit >= 0.85) return { label: 'のびやかな大木へ', color: '#7fd6a0', vit };
   if (vit >= 0.6) return { label: '健やかに茂る', color: '#bcd98a', vit };
   if (vit >= 0.32) return { label: 'ほどほどの繁り', color: '#e8b84b', vit };
-  return {
-    label: elapsedDays >= 28 ? '枯れ木 — 今月は不作' : '枯れ気味',
-    color: '#e08a5a',
-    vit,
-  };
+  return { label: '枯れ気味', color: '#e08a5a', vit };
 }


### PR DESCRIPTION
## 概要
トップに **「讚の庭」** — その月のいいねで育つ桜のアニメーションバナーを追加しました。Claude Design のハンドオフ（`design_handoff_zan_no_niwa`）を本プロジェクト（Next.js / React + Canvas）の規約に沿って実装したものです。

GitHub Profile の `Platane/snk` 翻案で、**毎日いいねを取り込むほど木が育ち、月末に大木になるか枯れ木になるかを観察できる**ことを狙っています。

## 主な連動ロジック
- **幹・枝** … その月の経過日数で強制成長（1日目=苗 → 月末=完成）
- **開花量** … その月のいいね総数で増減（少=枝が透ける枯れ木 / 多=満開の大木）
- **花の色** … いいねしたカテゴリ（`src/data/categories.ts` の 11 カテゴリ hue）
- **活力 → 判定** … いいね/日のペースで「大木⇄枯れ木」。過去月は確定結果、当月は予測表現で出し分け
- **インタラクション** … 木をタップすると揺れて花びらが散る

## 変更点
- `src/components/zan-no-niwa.tsx`（新規）— Canvas 描画の桜コンポーネント + `verdict()`
- `src/components/garden-top-banner.tsx`（新規）— バナー本体。判定ラベル / カテゴリ割合（植木下・右詰め）/ ヘルプ（Liquid Glass 風 popover・カテゴリ色凡例）/ 木エリア左右の月送りボタン
- `src/scripts/build-garden-stats.ts`（新規）— 月別 stats を集計し `public/garden-stats.json` を生成
- `src/components/home-tabs.tsx` / `src/app/page.tsx` — バナー設置とカレンダー（`displayMonth`）連動
- `.github/workflows/process-json.yml` — 毎日の取り込み Actions 末尾に `pnpm json:build-garden` を接続
- `package.json` / `CLAUDE.md` — スクリプト追加・ドキュメント更新
- `public/garden-stats.json` — 初期データ（月別・全20ヶ月）

## データ源の使い分け（2段階パイプラインに合わせる）
- **totalLikes / elapsedDays** … 日別 JSON（Actions が毎日 enrich する最新源）から月別集計。取り込んだ分だけ当月の木が育つ。
- **categoryWeights** … SQLite の `parent_category` から月別集計（花色の比率用）。カテゴリ分類はローカル手動運用なので、未分類の最新ツイートは色に寄与しない（graceful degrade）。
  - `source = 'ifttt'` に限定。アーカイブ（旧Twitterエクスポート 7,386件）は `liked_at` がインポート月（2025-06）に固まるため、混ぜると歪む。日別 JSON と母集団を揃える意味でも ifttt 限定。

## カレンダー連動
- トップのカレンダーで月を選ぶ（または木エリア左右の `‹ ›`）と、木・判定・カテゴリ割合・カレンダー本体がすべて同期して切り替わる。
- 過去月は満成長（その月の日数）、当月は今日まで。範囲外（最古より前・当月より先）はボタン無効化。

## レビュー時の補足
- `BLOOM_FULL=320` / `PACE_FOR_GREAT=10` は実データ（月 65〜325 件）で較正済み。今後ペースが変われば `zan-no-niwa.tsx` の `CFG` で調整可能。
- 反映フロー：Actions が `garden-stats.json` を毎日コミット＆push → Vercel 再デプロイ → 静的トップ再生成。花の「色」だけはローカル DB sync 時に最新化（Actions は SQLite に触れない既存方針のため）。
- 検証済み：`tsc --noEmit` / `next lint` クリーン、`pnpm build`（473 ページ）成功、localhost で各月切替・ヘルプ・月送りを目視確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)