### PR TITLE
💄 fix: 讚の庭のラベルに年を追加（YY年M月）

### DIFF
--- a/src/components/garden-top-banner.tsx
+++ b/src/components/garden-top-banner.tsx
@@ -27,10 +27,11 @@ export interface GardenData {
   months: Record<string, MonthStats>;
 }
 
-/** '2026-06' → '6月' */
+/** '2026-06' → '26年6月' */
 function monthLabel(month: string): string {
-  const m = month.split('-')[1];
-  return m ? `${Number(m)}月` : '今月';
+  const [y, m] = month.split('-');
+  if (!y || !m) return '今月';
+  return `${y.slice(2)}年${Number(m)}月`;
 }
 
 /** カテゴリ割合の上位を取り出す */


### PR DESCRIPTION
## 概要
トップの「讚の庭」バナーのラベルが月番号のみ（例: `6月`）で、**過去の年へ遡ったときに何年の木か分からない**問題を修正しました。

`YY年M月` 形式に変更：
- `2026-06` → **26年6月**
- `2025-07` → 25年7月
- `2024-11` → 24年11月

表示は「**26年6月 84 いいね**」のようになります。

## 変更点
- `src/components/garden-top-banner.tsx` — `monthLabel()` を `YY年M月` 形式に

## 補足
- #58（讚の庭バナー本体）のフォローアップです。
- `tsc --noEmit` 通過済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)